### PR TITLE
Решение ДЗ7

### DIFF
--- a/TinkoffApp.xcodeproj/project.pbxproj
+++ b/TinkoffApp.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		7D1930592523BDBC00227843 /* ChatViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1930572523BDBC00227843 /* ChatViewCell.swift */; };
 		7D19305A2523BDBC00227843 /* ChatViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D1930582523BDBC00227843 /* ChatViewCell.xib */; };
 		7D19305C2523BDE200227843 /* MessageCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D19305B2523BDE200227843 /* MessageCellModel.swift */; };
+		7D592B702549B36B008B90EC /* Chat.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7D592B6E2549B36B008B90EC /* Chat.xcdatamodeld */; };
+		7D592B722549B986008B90EC /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D592B712549B986008B90EC /* CoreDataStack.swift */; };
+		7D592B742549C242008B90EC /* ObjectsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D592B732549C242008B90EC /* ObjectsExtensions.swift */; };
+		7D592B76254A0D42008B90EC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D592B75254A0D42008B90EC /* CoreDataManager.swift */; };
+		7D592B78254B156C008B90EC /* CoreDataStackAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D592B77254B156C008B90EC /* CoreDataStackAsync.swift */; };
 		7D755F01253F921A009282BD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7D755F00253F921A009282BD /* GoogleService-Info.plist */; };
 		7D755F0325409C1C009282BD /* UserIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D755F0225409C1C009282BD /* UserIDManager.swift */; };
 		7D7C919525193283003D479C /* ProfileView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7D7C919425193283003D479C /* ProfileView.storyboard */; };
@@ -47,6 +52,11 @@
 		7D1930572523BDBC00227843 /* ChatViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewCell.swift; sourceTree = "<group>"; };
 		7D1930582523BDBC00227843 /* ChatViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChatViewCell.xib; sourceTree = "<group>"; };
 		7D19305B2523BDE200227843 /* MessageCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCellModel.swift; sourceTree = "<group>"; };
+		7D592B6F2549B36B008B90EC /* Chat.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Chat.xcdatamodel; sourceTree = "<group>"; };
+		7D592B712549B986008B90EC /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
+		7D592B732549C242008B90EC /* ObjectsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectsExtensions.swift; sourceTree = "<group>"; };
+		7D592B75254A0D42008B90EC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		7D592B77254B156C008B90EC /* CoreDataStackAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStackAsync.swift; sourceTree = "<group>"; };
 		7D755F00253F921A009282BD /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		7D755F0225409C1C009282BD /* UserIDManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIDManager.swift; sourceTree = "<group>"; };
 		7D7C919425193283003D479C /* ProfileView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ProfileView.storyboard; sourceTree = "<group>"; };
@@ -135,6 +145,17 @@
 			name = ViewControllers;
 			sourceTree = "<group>";
 		};
+		7D592B6D2549B353008B90EC /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				7D592B6E2549B36B008B90EC /* Chat.xcdatamodeld */,
+				7D592B712549B986008B90EC /* CoreDataStack.swift */,
+				7D592B732549C242008B90EC /* ObjectsExtensions.swift */,
+				7D592B77254B156C008B90EC /* CoreDataStackAsync.swift */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
 		7D9BD54D251124FB00C7EFE8 = {
 			isa = PBXGroup;
 			children = (
@@ -156,6 +177,7 @@
 		7D9BD558251124FB00C7EFE8 /* TinkoffApp */ = {
 			isa = PBXGroup;
 			children = (
+				7D592B6D2549B353008B90EC /* CoreData */,
 				7D755F00253F921A009282BD /* GoogleService-Info.plist */,
 				7DB00D7C252D8AEB00DE922A /* Services */,
 				7D19305E252502F600227843 /* ViewControllers */,
@@ -179,6 +201,7 @@
 				7DA599A52536376900B0F078 /* OperationDataManager.swift */,
 				7DA599A72537583200B0F078 /* DataManager.swift */,
 				7D755F0225409C1C009282BD /* UserIDManager.swift */,
+				7D592B75254A0D42008B90EC /* CoreDataManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -329,6 +352,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D592B78254B156C008B90EC /* CoreDataStackAsync.swift in Sources */,
 				7D9BD55E251124FB00C7EFE8 /* ViewController.swift in Sources */,
 				7D19305C2523BDE200227843 /* MessageCellModel.swift in Sources */,
 				7DB00D7B252D1FFB00DE922A /* ThemesPickerDelegate.swift in Sources */,
@@ -338,12 +362,16 @@
 				7D19304425234B7200227843 /* ConversationCellModel.swift in Sources */,
 				7D19304725234C1700227843 /* ConfigurableView.swift in Sources */,
 				7D1930592523BDBC00227843 /* ChatViewCell.swift in Sources */,
+				7D592B702549B36B008B90EC /* Chat.xcdatamodeld in Sources */,
+				7D592B76254A0D42008B90EC /* CoreDataManager.swift in Sources */,
 				7DA599A82537583200B0F078 /* DataManager.swift in Sources */,
 				7D7C9197251932D5003D479C /* ProfileViewController.swift in Sources */,
 				7D755F0325409C1C009282BD /* UserIDManager.swift in Sources */,
 				7D9BD55A251124FB00C7EFE8 /* AppDelegate.swift in Sources */,
 				7DA599A62536376900B0F078 /* OperationDataManager.swift in Sources */,
+				7D592B722549B986008B90EC /* CoreDataStack.swift in Sources */,
 				7DB00D76252D0FF500DE922A /* ThemesViewController.swift in Sources */,
+				7D592B742549C242008B90EC /* ObjectsExtensions.swift in Sources */,
 				7DA599A42536375900B0F078 /* GCDDataManager.swift in Sources */,
 				7D19304A25234CB000227843 /* ConversationViewCell.swift in Sources */,
 				7DB00D7E252D8B1100DE922A /* ThemeManager.swift in Sources */,
@@ -548,6 +576,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		7D592B6E2549B36B008B90EC /* Chat.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				7D592B6F2549B36B008B90EC /* Chat.xcdatamodel */,
+			);
+			currentVersion = 7D592B6F2549B36B008B90EC /* Chat.xcdatamodel */;
+			path = Chat.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 7D9BD54E251124FB00C7EFE8 /* Project object */;
 }

--- a/TinkoffApp/AppDelegate.swift
+++ b/TinkoffApp/AppDelegate.swift
@@ -17,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         FirebaseApp.configure()
         UserIDManager.loadId()
+        // Читаем все сохраненные данные
+        CoreDataManager.readAllData()
         return true
     }
 

--- a/TinkoffApp/ConversationViewController.swift
+++ b/TinkoffApp/ConversationViewController.swift
@@ -82,12 +82,12 @@ class ConversationViewController: UIViewController {
                 let created = data["created"] as? Timestamp,
                 let content = data["content"] as? String,
                 let senderId = data["senderId"] as? String, !content.isEmpty {
-                
-                messages.append(.init(content: content, created: created.dateValue(), senderId: senderId, senderName: senderName))
+                messages.append(.init(messageId: document.documentID, content: content, created: created.dateValue(), senderId: senderId, senderName: senderName))
             }
-            messages.sort(by: {$0.created.compare($1.created) == .orderedAscending})
             
         }
+        messages.sort(by: {$0.created.compare($1.created) == .orderedAscending})
+        CoreDataManager.save(messages: messages)
     }
     @IBAction func sendNewMessage(_ sender: Any) {
         if let message = newMessageField.text, !message.isEmpty, let userId = UserIDManager.userId {

--- a/TinkoffApp/ConversationsListViewController.swift
+++ b/TinkoffApp/ConversationsListViewController.swift
@@ -68,10 +68,12 @@ class ConversationsListViewController: UITableViewController, ThemesPickerDelega
                 let lastMessage = data["lastMessage"] as? String
                 let lastActivity = (data["lastActivity"] as? Timestamp)?.dateValue()
                 channels.append(Channel(identifier: document.documentID, name: name, lastMessage: lastMessage, lastActivity: lastActivity))
-                
             }
         }
+        CoreDataManager.save(channels: channels)
+        
     }
+    var coreDataStack = CoreDataStack()
     @IBAction func addNewChennel(_ sender: Any) {
         let alert = UIAlertController(title: "Новый канал", message: "Введите название нового канала", preferredStyle: .alert)
         alert.addTextField(configurationHandler: nil)

--- a/TinkoffApp/CoreData/Chat.xcdatamodeld/Chat.xcdatamodel/contents
+++ b/TinkoffApp/CoreData/Chat.xcdatamodeld/Chat.xcdatamodel/contents
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19F101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Channel_db" representedClassName="Channel_db" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="lastActivity" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastMessage" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="identifier"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Message_db" representedClassName="Message_db" syncable="YES" codeGenerationType="class">
+        <attribute name="content" attributeType="String"/>
+        <attribute name="created" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="messageId" attributeType="String"/>
+        <attribute name="senderId" attributeType="String"/>
+        <attribute name="senderName" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="messageId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <elements>
+        <element name="Channel_db" positionX="-326.66015625" positionY="-31.69921875" width="114.0859375" height="103"/>
+        <element name="Message_db" positionX="-54" positionY="-9" width="128" height="118"/>
+    </elements>
+</model>

--- a/TinkoffApp/CoreData/CoreDataStack.swift
+++ b/TinkoffApp/CoreData/CoreDataStack.swift
@@ -1,0 +1,143 @@
+//
+//  CoreDataStack.swift
+//  TinkoffApp
+//
+//  Created by Михаил on 28.10.2020.
+//  Copyright © 2020 Tinkoff. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+class  CoreDataStack {
+    var didUpdateDataBase: ((CoreDataStack) -> Void)?
+
+    private var storeURL: URL = {
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last else {
+            fatalError("document has not found")
+        }
+        return documentsURL.appendingPathComponent("Chat.sqlite")
+    }()
+    
+    private let dataModelName = "Chat"
+    private let dataModelExtension = "momd"
+    
+    private(set) lazy var managedObjectModel: NSManagedObjectModel = {
+        guard let modelURL = Bundle.main.url(forResource: self.dataModelName, withExtension: self.dataModelExtension) else {
+            fatalError("model not found")
+        }
+        guard let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("managedObjectModel cound not ve created")
+        }
+        return managedObjectModel
+    }()
+    
+    private lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator = {
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
+        do {
+            try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: self.storeURL, options: nil)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+        return coordinator
+    }()
+    
+    private lazy var writterContext: NSManagedObjectContext = {
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.persistentStoreCoordinator = persistentStoreCoordinator
+        context.mergePolicy = NSOverwriteMergePolicy
+        return context
+    }()
+    
+    private(set) lazy var mainContext: NSManagedObjectContext = {
+        let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        context.parent = writterContext
+        context.automaticallyMergesChangesFromParent = true
+        context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+        return context
+    }()
+    
+    private func saveContext() -> NSManagedObjectContext {
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.parent = mainContext
+        context.automaticallyMergesChangesFromParent = true
+        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return context
+    }
+    
+    // MARK: - Save Context
+    
+    func performSave(_ block: @escaping (NSManagedObjectContext) -> Void) {
+        let context = self.saveContext()
+        
+        context.performAndWait {
+            block(context)
+            if context.hasChanges {
+                self.performSave(in: context)
+            }
+        }
+        
+    }
+    
+    private func performSave(in context: NSManagedObjectContext) {
+        if context == writterContext {
+            context.perform {
+                do {
+                    try context.save()
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                }
+            }
+        } else {
+            context.performAndWait {
+                do {
+                    try context.save()
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                }
+            }
+            if let parent = context.parent { self.performSave(in: parent) }
+            
+        }
+        
+    }
+    func enableObservers() {
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(self, selector:
+                                       #selector(managedObjectContextObjectsDidChange),
+                                       name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+                                       object: mainContext)
+    }
+    @objc
+    private func managedObjectContextObjectsDidChange(notification: NSNotification) {
+        guard let userInfo = notification.userInfo else { return }
+        printSaved()
+        if let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>, inserts.count > 0 {
+            NSLog("Добавлено объектов: \(inserts.count)")
+        }
+        if let update = userInfo[NSUpdatedObjectsKey] as? Set<NSManagedObject>, update.count > 0 {
+            NSLog("Обновлено объектов: \(update.count)")
+        }
+        if let deletes = userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>, deletes.count > 0 {
+            NSLog("Удалено объектов: \(deletes.count)")
+        }
+        
+    }
+    
+    private func printSaved(_ message: String = "") {
+        mainContext.perform {
+            do {
+                let channels = try self.mainContext.fetch( Channel_db.fetchRequest()) as? [Channel_db] ?? []
+                let messages = try self.mainContext.fetch( Message_db.fetchRequest()) as? [Message_db] ?? []
+                NSLog("\(message)Число сохраненных каналов: \(channels.count), Число сохраненных сообщений: \(messages.count)")
+            } catch {
+                fatalError(error.localizedDescription)
+            }
+        }
+    }
+    func printSavedData(with message: String) {
+        DispatchQueue.global().async {
+            self.printSaved(message)
+        }
+    }
+}

--- a/TinkoffApp/CoreData/CoreDataStackAsync.swift
+++ b/TinkoffApp/CoreData/CoreDataStackAsync.swift
@@ -1,0 +1,146 @@
+//
+//  CoreDataStackAsync.swift
+//  TinkoffApp
+//
+//  Created by Михаил on 29.10.2020.
+//  Copyright © 2020 Tinkoff. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+class  CoreDataStackAsync {
+    
+    let queue = DispatchQueue(label: "corequeue")
+    init() {
+        queue.async {
+            guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last else {
+                fatalError("document has not found")
+            }
+            self.storeURL = documentsURL.appendingPathComponent("Chat.sqlite")
+            guard let modelURL = Bundle.main.url(forResource: self.dataModelName, withExtension: self.dataModelExtension) else {
+                fatalError("model not found")
+            }
+            guard let managedObject = NSManagedObjectModel(contentsOf: modelURL) else {
+                fatalError("managedObjectModel cound not ve created")
+            }
+            self.managedObjectModel = managedObject
+            let coordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObject)
+            do {
+                try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: self.storeURL, options: nil)
+            } catch {
+                fatalError(error.localizedDescription)
+            }
+            self.persistentStoreCoordinator = coordinator
+            let wContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+            wContext.persistentStoreCoordinator = coordinator
+            wContext.mergePolicy = NSOverwriteMergePolicy
+            self.writterContext = wContext
+            let mContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+            mContext.parent = wContext
+            mContext.automaticallyMergesChangesFromParent = true
+            mContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+            self.mainContext = mContext
+        }
+        
+    }
+    
+    private var storeURL: URL?
+    
+    private let dataModelName = "Chat"
+    private let dataModelExtension = "momd"
+    
+    private(set) var managedObjectModel: NSManagedObjectModel?
+    
+    private var persistentStoreCoordinator: NSPersistentStoreCoordinator?
+    
+    private var writterContext: NSManagedObjectContext?
+    
+    private(set) var mainContext: NSManagedObjectContext?
+    
+    private func saveContext() -> NSManagedObjectContext {
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.parent = mainContext
+        context.automaticallyMergesChangesFromParent = true
+        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return context
+    }
+    
+    // MARK: - Save Context
+    
+    func performSave(_ block: @escaping (NSManagedObjectContext) -> Void) {
+        queue.async {
+            let context = self.saveContext()
+            context.performAndWait {
+                block(context)
+                if context.hasChanges {
+                    self.performSave(in: context)
+                }
+            }
+            
+        }
+        
+    }
+    
+    private func performSave(in context: NSManagedObjectContext) {
+        if context == writterContext {
+            context.perform {
+                do {
+                    try context.save()
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                }
+            }
+        } else {
+            context.performAndWait {
+                do {
+                    try context.save()
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                }
+            }
+            if let parent = context.parent { self.performSave(in: parent) }
+            
+        }
+        
+    }
+    func enableObservers() {
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(self, selector:
+            #selector(managedObjectContextObjectsDidChange),
+                                       name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+                                       object: mainContext)
+    }
+    @objc
+    private func managedObjectContextObjectsDidChange(notification: NSNotification) {
+        guard let userInfo = notification.userInfo else { return }
+        printSaved()
+        if let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>, inserts.count > 0 {
+            NSLog("Добавлено объектов: \(inserts.count)")
+        }
+        if let update = userInfo[NSUpdatedObjectsKey] as? Set<NSManagedObject>, update.count > 0 {
+            NSLog("Обновлено объектов: \(update.count)")
+        }
+        if let deletes = userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>, deletes.count > 0 {
+            NSLog("Удалено объектов: \(deletes.count)")
+        }
+        
+    }
+    
+    private func printSaved(_ message: String = "") {
+        mainContext?.perform {
+            do {
+                let channels = try self.mainContext?.fetch( Channel_db.fetchRequest()) as? [Channel_db] ?? []
+                let messages = try self.mainContext?.fetch( Message_db.fetchRequest()) as? [Message_db] ?? []
+                NSLog("\(message)Число сохраненных каналов: \(channels.count), Число сохраненных сообщений: \(messages.count)")
+            } catch {
+                fatalError(error.localizedDescription)
+            }
+        }
+    }
+    func printSavedData(with message: String) {
+        queue.async {
+            self.printSaved(message)
+        }
+    }
+}

--- a/TinkoffApp/CoreData/ObjectsExtensions.swift
+++ b/TinkoffApp/CoreData/ObjectsExtensions.swift
@@ -1,0 +1,31 @@
+//
+//  ObjectsExtensions.swift
+//  TinkoffApp
+//
+//  Created by Михаил on 28.10.2020.
+//  Copyright © 2020 Tinkoff. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+extension Message_db {
+    convenience init(message: Message, in context: NSManagedObjectContext) {
+        self.init(context: context)
+        senderName = message.senderName
+        senderId = message.senderId
+        created = message.created
+        content = message.content
+        messageId = message.messageId
+    }
+}
+
+extension Channel_db {
+    convenience init(channel: Channel, in context: NSManagedObjectContext) {
+        self.init(context: context)
+        identifier = channel.identifier
+        name = channel.name
+        lastMessage = channel.lastMessage
+        lastActivity = channel.lastActivity
+    }
+}

--- a/TinkoffApp/Models/MessageCellModel.swift
+++ b/TinkoffApp/Models/MessageCellModel.swift
@@ -17,7 +17,7 @@ struct Message {
 //        case input
 //        case output
 //    }
-    
+    let messageId: String
     let content: String
     let created: Date
     let senderId: String

--- a/TinkoffApp/Services/CoreDataManager.swift
+++ b/TinkoffApp/Services/CoreDataManager.swift
@@ -1,0 +1,73 @@
+//
+//  CoreDataManager.swift
+//  TinkoffApp
+//
+//  Created by Михаил on 28.10.2020.
+//  Copyright © 2020 Tinkoff. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataManager {
+    
+    private static var coreDataStack: CoreDataStack = {
+        let stack = CoreDataStack()
+        stack.enableObservers()
+        return stack
+    }()
+    private static var coreAsync: CoreDataStackAsync = {
+        let stack = CoreDataStackAsync()
+        stack.enableObservers()
+        return stack
+    }()
+    /**
+     Сохраняем каналы
+     
+     - Parameter channels: Каналы, которые необходимо сохранить.
+     */
+    static func save(channels: [Channel]) {
+                coreDataStack.performSave { context in
+                    for channel in channels {
+                        _ = Channel_db(channel: channel, in: context)
+                    }
+                }
+        
+        // MARK: - CoreDataStackAsync сохранение каналов
+        
+//        coreAsync.performSave { context in
+//            for channel in channels {
+//                _ = Channel_db(channel: channel, in: context)
+//            }
+//        }
+        
+    }
+    /**
+     Сохраняем сообщения
+     
+     - Parameter messages: Сообщения, которые необходимо сохранить.
+     */
+    static func save(messages: [Message]) {
+                coreDataStack.performSave { context in
+                    for message in messages {
+                        _ = Message_db(message: message, in: context)
+                    }
+                }
+        // MARK: - CoreDataStackAsync сохранение сообщений
+        
+//        coreAsync.performSave { context in
+//            for message in messages {
+//                _ = Message_db(message: message, in: context)
+//            }
+//        }
+    }
+    /// Читает все сообщения и выводит в логи
+    static func readAllData() {
+        coreDataStack.printSavedData(with: "На устройстве: ")
+        
+        // MARK: - CoreDataStackAsync чтение сохраненных данных
+        
+        //coreAsync.printSavedData(with: "На устройстве: ")
+    }
+    
+}

--- a/TinkoffApp/Services/UserIDManager.swift
+++ b/TinkoffApp/Services/UserIDManager.swift
@@ -20,6 +20,5 @@ class UserIDManager {
         } else {
             userId = id
         }
-        //let identifier = UUID()
     }
 }


### PR DESCRIPTION
добавлено сохранение каналов и сообщений в core data
сообщения сохраняются только, если был открыт соответсвующий канал
реализовано два стека CoreDataStack и CoreDataStackAsync, последний обрабатывает асинхронно кейс когда загрузка стека может быть долгой
для теста CoreDataStackAsync необходимо распоменнтировать соответсвующий код в CoreDataManager